### PR TITLE
Use existing Program ID (don't generate each time). Also set default provider to be `localnet`.

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,5 +1,9 @@
 [features]
 seeds = false
+
+[programs.localnet]
+flobrij = "6nLbF7aMUH9GYsBFkW3uRA117p122rgN5P6UVwiBi9ve"
+
 [programs.devnet]
 flobrij = "6nLbF7aMUH9GYsBFkW3uRA117p122rgN5P6UVwiBi9ve"
 
@@ -7,7 +11,7 @@ flobrij = "6nLbF7aMUH9GYsBFkW3uRA117p122rgN5P6UVwiBi9ve"
 url = "https://anchor.projectserum.com"
 
 [provider]
-cluster = "devnet"
+cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]

--- a/README.md
+++ b/README.md
@@ -19,18 +19,6 @@ In a second terminal window, build and deploy the contract via:
     solana airdrop 5    # if your wallet is empty
     anchor deploy
 
-Update Anchor.toml with these two changes
-
-```
-[programs.localnet]
-flobrij = "PROGRAM ID FROM DEPLOY STEP ABOVE"
-```
-
-```
-[provider]
-cluster = "localnet"
-```
-
 ## Copy IDL to front-end
 
     cp target/idl/flobrij.json ~/flobrij-frontend/src/


### PR DESCRIPTION
Localnet should use same program ID as devnet and doesn’t need to be generated each time.

Also make default provider localnet.

Removed unneeded manual step in README.

This also fixes the Anchor tests that were failing due to incorrect program ID.