### PR TITLE
Clarify create_receipt params. Test clean-up.

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+    "trailingComma": "es5",
+    "tabWidth": 2,
+    "semi": true,
+    "singleQuote": true
+}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Copy IDL to front-end
 
     yarn install
 
+## Run code formatter on tests
+
+    yarn style
+
 **Make sure you don't have solana-test-validator running before running tests**
 
     anchor test     # which runs validator and tests in one go

--- a/package.json
+++ b/package.json
@@ -2,10 +2,14 @@
     "dependencies": {
         "@project-serum/anchor": "^0.21.0"
     },
+    "scripts": {
+        "style": "prettier --write tests"
+    },
     "devDependencies": {
         "@types/mocha": "^9.0.0",
         "chai": "^4.3.4",
         "mocha": "^9.0.3",
+        "prettier": "^2.5.1",
         "ts-mocha": "^9.0.2",
         "typescript": "^4.3.5"
     }

--- a/programs/flobrij/src/lib.rs
+++ b/programs/flobrij/src/lib.rs
@@ -8,15 +8,17 @@ declare_id!("6nLbF7aMUH9GYsBFkW3uRA117p122rgN5P6UVwiBi9ve");
 pub mod flobrij {
     use super::*;
     pub fn create_receipt(ctx: Context<CreateReceipt>, 
-        transaction: Pubkey, 
-        recipient: Pubkey, 
+        patron_payment_transaction: Pubkey, 
+        creator: Pubkey, 
         email: String, 
         amount: u32, 
         expiration_hours: u16
     ) -> ProgramResult {
+
+        msg!("Some variable: {:?}", patron_payment_transaction);
         /*
         * TODO: 
-        *  - We should look up the transaction and pull it's information instead of just taking it from the call. Figure this out later.
+        *  - We should look up the patron_payment_transaction and pull it's information instead of just taking it from the call. Figure this out later.
         */ 
         let receipt: &mut Account<Receipt> = &mut ctx.accounts.receipt; 
         let payer: &Signer = &ctx.accounts.payer; 
@@ -25,15 +27,15 @@ pub mod flobrij {
         receipt.payer = *payer.key; 
         receipt.timestamp = clock.unix_timestamp; 
 
-        // TODO: Get transaction information, make sure it's a valid transaction
-        //      - Make sure the payer and the recipient match the transaction as well as the amount
+        // TODO: Get patron_payment_transaction information, make sure it's a valid patron_payment_transaction
+        //      - Make sure the payer and the recipient match the patron_payment_transaction as well as the amount
 
         if email.chars().count() > 254 {
             return Err(ErrorCode::EmailTooLong.into())
         }
 
-        receipt.transaction = transaction; 
-        receipt.recipient = recipient; 
+        receipt.transaction = patron_payment_transaction; 
+        receipt.recipient = creator; 
         receipt.email = email; 
         receipt.amount = amount; 
         receipt.expiration_hours = expiration_hours; 

--- a/tests/flobrij.ts
+++ b/tests/flobrij.ts
@@ -2,24 +2,21 @@ import * as anchor from '@project-serum/anchor';
 import { Program } from '@project-serum/anchor';
 import { Flobrij } from '../target/types/flobrij';
 import * as assert from 'assert';
-import * as bs58 from "bs58";
 
 describe('flobrij', () => {
-
-  // Configure the client to use the local cluster.
   anchor.setProvider(anchor.Provider.env());
 
   const program = anchor.workspace.Flobrij as Program<Flobrij>;
 
-  const EMAIL = 'akarys92@gmail.com';
-  const TEST_AMOUNT = 5000; 
-  const EXP_HOURS = 8760; 
-  const FAKE_RECIPIENT = anchor.web3.Keypair.generate(); 
+  const EMAIL = 'test@test.com';
+  const TEST_AMOUNT = 5000;
+  const EXP_HOURS = 8760;
+  const TEST_CREATOR = anchor.web3.Keypair.generate();
+  const AIRDROP_AMOUNT = 1000000000;
 
-  it('Create a receipt!', async () => {
-    const receipt = anchor.web3.Keypair.generate(); 
-    const fakeTransaction = anchor.web3.Keypair.generate(); 
-    // Add your test here.
+  it('Create a receipt', async () => {
+    const receipt = anchor.web3.Keypair.generate();
+    const fakeTransaction = anchor.web3.Keypair.generate();
     /*
       transaction: Pubkey, 
       recipient: Pubkey, 
@@ -27,115 +24,161 @@ describe('flobrij', () => {
       amount: u32, 
       expiration_hours: u16
     */
-    const tx = await program.rpc.createReceipt(fakeTransaction.publicKey, FAKE_RECIPIENT.publicKey, EMAIL, 5000, EXP_HOURS, {
+    const tx = await program.rpc.createReceipt(
+      fakeTransaction.publicKey,
+      TEST_CREATOR.publicKey,
+      EMAIL,
+      TEST_AMOUNT,
+      EXP_HOURS,
+      {
         accounts: {
           // Accounts here...
-          receipt: receipt.publicKey, 
-          payer: program.provider.wallet.publicKey, 
+          receipt: receipt.publicKey,
+          payer: program.provider.wallet.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,
-      },
-      signers: [
-          // Key pairs of signers here...
-          receipt
-      ],
-    });
-    console.log("Your transaction signature", tx);
-    const receiptAccount = await program.account.receipt.fetch(receipt.publicKey); 
-    console.log(receiptAccount);
-  });
-
-  it('Create a receipt as a different user!', async () => {
-    const receipt = anchor.web3.Keypair.generate(); 
-    const fakeRecipient = anchor.web3.Keypair.generate(); 
-    const fakeTransaction = anchor.web3.Keypair.generate(); 
-    const fakeUser = anchor.web3.Keypair.generate(); 
-    const signature = await program.provider.connection.requestAirdrop(fakeUser.publicKey, 1000000000);
-    await program.provider.connection.confirmTransaction(signature);
-    // Add your test here.
-    /*
-      transaction: Pubkey, 
-      recipient: Pubkey, 
-      email: String, 
-      amount: u32, 
-      expiration_hours: u16
-    */
-    const tx = await program.rpc.createReceipt(fakeTransaction.publicKey, fakeRecipient.publicKey, EMAIL, 5000, EXP_HOURS, {
-        accounts: {
-          // Accounts here...
-          receipt: receipt.publicKey, 
-          payer: fakeUser.publicKey, 
-          systemProgram: anchor.web3.SystemProgram.programId,
-      },
-      signers: [
+        },
+        signers: [
           // Key pairs of signers here...
           receipt,
-          fakeUser
-      ],
-    });
-    console.log("Your transaction signature", tx);
-    const receiptAccount = await program.account.receipt.fetch(receipt.publicKey); 
+        ],
+      }
+    );
+
+    const receiptAccount = await program.account.receipt.fetch(
+      receipt.publicKey
+    );
+
+    console.log(receiptAccount);
+
+    // assert.equal(program.provider.wallet.publicKey.toString(), TEST_CREATOR.secretKey.toString());
+
+    assert.equal(receiptAccount.email, EMAIL);
+    assert.equal(receiptAccount.amount, TEST_AMOUNT);
+    assert.equal(receiptAccount.expirationHours, EXP_HOURS);
+  });
+
+  it('Create a receipt as a different user', async () => {
+    const receipt = anchor.web3.Keypair.generate();
+    const fakeRecipient = anchor.web3.Keypair.generate();
+    const fakeTransaction = anchor.web3.Keypair.generate();
+    const fakeUser = anchor.web3.Keypair.generate();
+    const signature = await program.provider.connection.requestAirdrop(
+      fakeUser.publicKey,
+      AIRDROP_AMOUNT
+    );
+    await program.provider.connection.confirmTransaction(signature);
+    /*
+      transaction: Pubkey,
+      recipient: Pubkey,
+      email: String,
+      amount: u32,
+      expiration_hours: u16
+    */
+    const tx = await program.rpc.createReceipt(
+      fakeTransaction.publicKey,
+      fakeRecipient.publicKey,
+      EMAIL,
+      TEST_AMOUNT,
+      EXP_HOURS,
+      {
+        accounts: {
+          // Accounts here...
+          receipt: receipt.publicKey,
+          payer: fakeUser.publicKey,
+          systemProgram: anchor.web3.SystemProgram.programId,
+        },
+        signers: [
+          // Key pairs of signers here...
+          receipt,
+          fakeUser,
+        ],
+      }
+    );
+    const receiptAccount = await program.account.receipt.fetch(
+      receipt.publicKey
+    );
     console.log(receiptAccount);
   });
 
-  it('Query for receipts by payee', async() => {
-    const recipientPublicKey = FAKE_RECIPIENT.publicKey; 
+  it('Query for receipts by payee', async () => {
+    const recipientPublicKey = TEST_CREATOR.publicKey;
     const receiptAccounts = await program.account.receipt.all([
       {
         memcmp: {
-          offset: 8
-            + 32, // Transaction key, 
+          offset: 8 + 32, // Transaction key,
           bytes: recipientPublicKey.toBase58(),
-        }
-      }
+        },
+      },
     ]);
 
-    assert.equal(receiptAccounts.length, 1); 
-    assert.ok(receiptAccounts.every(recipientAccounts =>{
-      return recipientAccounts.account.recipient.toBase58() === recipientPublicKey.toBase58();
-    })); 
-
+    assert.equal(receiptAccounts.length, 1);
+    assert.ok(
+      receiptAccounts.every((recipientAccounts) => {
+        return (
+          recipientAccounts.account.recipient.toBase58() ===
+          recipientPublicKey.toBase58()
+        );
+      })
+    );
   });
 
-  it('Send and retrieve to me', async() => { 
-    const receipt = anchor.web3.Keypair.generate(); 
-    const fakeRecipient = new anchor.web3.PublicKey("EjVxdTp7NXqUtqSACXeMojnTUwkFhr1wd5rxmDSLrstd")
-    
-    const fakeTransaction = anchor.web3.Keypair.generate(); 
-    const fakeUser = anchor.web3.Keypair.generate(); 
-    const signature = await program.provider.connection.requestAirdrop(fakeUser.publicKey, 1000000000);
+  it('Send and retrieve to me', async () => {
+    const receipt = anchor.web3.Keypair.generate();
+    const fakeRecipient = new anchor.web3.PublicKey(
+      'EjVxdTp7NXqUtqSACXeMojnTUwkFhr1wd5rxmDSLrstd'
+    );
+
+    const fakeTransaction = anchor.web3.Keypair.generate();
+    const fakeUser = anchor.web3.Keypair.generate();
+    const signature = await program.provider.connection.requestAirdrop(
+      fakeUser.publicKey,
+      AIRDROP_AMOUNT
+    );
     await program.provider.connection.confirmTransaction(signature);
 
-    const tx = await program.rpc.createReceipt(fakeTransaction.publicKey, fakeRecipient, EMAIL, 5000, EXP_HOURS, {
+    const tx = await program.rpc.createReceipt(
+      fakeTransaction.publicKey,
+      fakeRecipient,
+      EMAIL,
+      TEST_AMOUNT,
+      EXP_HOURS,
+      {
         accounts: {
           // Accounts here...
-          receipt: receipt.publicKey, 
-          payer: fakeUser.publicKey, 
+          receipt: receipt.publicKey,
+          payer: fakeUser.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,
-      },
-      signers: [
+        },
+        signers: [
           // Key pairs of signers here...
           receipt,
-          fakeUser
-      ],
-    });
-    console.log("Your transaction signature", tx);
-    const receiptAccount = await program.account.receipt.fetch(receipt.publicKey); 
+          fakeUser,
+        ],
+      }
+    );
+    console.log('Your transaction signature', tx);
+    const receiptAccount = await program.account.receipt.fetch(
+      receipt.publicKey
+    );
     console.log(receiptAccount);
 
     const receiptAccounts = await program.account.receipt.all([
       {
         memcmp: {
-          offset: 8
-            + 32, // Transaction key, 
-          bytes: fakeRecipient,
-        }
-      }
+          offset: 8 + 32, // Transaction key,
+          bytes: fakeRecipient.toString(),
+        },
+      },
     ]);
     console.log("\n\n This is the account that's interesting: ");
     console.log(receiptAccounts);
-    assert.ok(receiptAccounts.every(recipientAccounts =>{
-      return recipientAccounts.account.recipient.toBase58() === fakeRecipient.toBase58();
-    })); 
-
+    assert.ok(
+      receiptAccounts.every((recipientAccounts) => {
+        return (
+          recipientAccounts.account.recipient.toBase58() ===
+          fakeRecipient.toBase58()
+        );
+      })
+    );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -918,6 +918,11 @@ picomatch@^2.0.4, picomatch@^2.2.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+prettier@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
+  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
+
 randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"


### PR DESCRIPTION
Mainly test clean-up. Also tweaked `create_receipt` params to make it a bit more clear.

Test clean-up:

- start adding assertions -- current tests validate creation, but don’t verify actual values are set correctly

- Add prettier and `yarn style` script to keep test code consistently formatted.

- sprinkle in some more constants