### PR TITLE
Transfer payment from Patron to Creator in create_receipt. Remove transaction step from front-end.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,14 @@ Copy IDL to front-end
 
     yarn install
 
+**Make sure you don't have solana-test-validator running before running tests**
+
+    anchor test     # which runs validator and tests in one go
+
 ## Run code formatter on tests
 
     yarn style
 
-**Make sure you don't have solana-test-validator running before running tests**
+## How do I debug Rust by logging variables?
 
-    anchor test     # which runs validator and tests in one go
+I created a gist with more info: https://gist.github.com/briangershon/89dfe197941c0abbd26db991ce350ce5

--- a/programs/flobrij/src/lib.rs
+++ b/programs/flobrij/src/lib.rs
@@ -1,5 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::system_program;
+use anchor_lang::solana_program::system_instruction;
 
 
 declare_id!("6nLbF7aMUH9GYsBFkW3uRA117p122rgN5P6UVwiBi9ve");
@@ -10,12 +11,11 @@ pub mod flobrij {
     pub fn create_receipt(ctx: Context<CreateReceipt>, 
         patron_payment_transaction: Pubkey, 
         creator: Pubkey, 
-        email: String, 
-        amount: u32, 
+        email: String,
+        amount: u64,
         expiration_hours: u16
     ) -> ProgramResult {
 
-        msg!("Some variable: {:?}", patron_payment_transaction);
         /*
         * TODO: 
         *  - We should look up the patron_payment_transaction and pull it's information instead of just taking it from the call. Figure this out later.
@@ -34,6 +34,20 @@ pub mod flobrij {
             return Err(ErrorCode::EmailTooLong.into())
         }
 
+        // first Patron should pay Creator
+        let ix = system_instruction::transfer(
+            &ctx.accounts.payer.key(),
+            &ctx.accounts.creator.key(),
+            amount,
+        );
+        anchor_lang::solana_program::program::invoke(
+            &ix,
+            &[
+                ctx.accounts.payer.to_account_info(),
+                ctx.accounts.creator.to_account_info(),
+            ],
+        ).unwrap_or_else(|err| println!("{:?}", err));
+
         receipt.transaction = patron_payment_transaction; 
         receipt.recipient = creator; 
         receipt.email = email; 
@@ -49,6 +63,8 @@ pub struct CreateReceipt<'info> {
     #[account(init, payer = payer, space = Receipt::LEN)]
     pub receipt: Account<'info, Receipt>, 
     #[account(mut)]
+    pub creator: Signer<'info>,
+    #[account(mut)]
     pub payer: Signer<'info>, 
     #[account(address = system_program::ID)]
     pub system_program: AccountInfo<'info>
@@ -61,7 +77,7 @@ pub struct Receipt {
     pub timestamp: i64, 
     pub expiration_hours: u16, 
     pub email: String, 
-    pub amount: u32, 
+    pub amount: u64,
     pub transaction: Pubkey, 
 }
 
@@ -74,7 +90,7 @@ const EXPIRATION_HOURS_LENGTH: usize = 2;
 // Email is max 254 characters
 const STRING_LENGTH_PREFIX: usize = 4; // Stores the size of the string.
 const MAX_EMAIL_LENGTH: usize = 254 * 4; // 254 chars max.
-const AMOUNT_LENGTH: usize = 4; 
+const AMOUNT_LENGTH: usize = 8;
 const TRANSACTION_PUBLIC_KEY_LENGTH: usize = 32;
 
 impl Receipt {

--- a/programs/flobrij/src/lib.rs
+++ b/programs/flobrij/src/lib.rs
@@ -9,17 +9,10 @@ declare_id!("6nLbF7aMUH9GYsBFkW3uRA117p122rgN5P6UVwiBi9ve");
 pub mod flobrij {
     use super::*;
     pub fn create_receipt(ctx: Context<CreateReceipt>, 
-        patron_payment_transaction: Pubkey, 
-        creator: Pubkey, 
         email: String,
         amount: u64,
         expiration_hours: u16
     ) -> ProgramResult {
-
-        /*
-        * TODO: 
-        *  - We should look up the patron_payment_transaction and pull it's information instead of just taking it from the call. Figure this out later.
-        */ 
         let receipt: &mut Account<Receipt> = &mut ctx.accounts.receipt; 
         let payer: &Signer = &ctx.accounts.payer; 
         let clock: Clock = Clock::get().unwrap();
@@ -48,8 +41,7 @@ pub mod flobrij {
             ],
         ).unwrap_or_else(|err| println!("{:?}", err));
 
-        receipt.transaction = patron_payment_transaction; 
-        receipt.recipient = creator; 
+        receipt.recipient = ctx.accounts.creator.key(); //  .creator.pub(); //creator; 
         receipt.email = email; 
         receipt.amount = amount; 
         receipt.expiration_hours = expiration_hours; 
@@ -78,7 +70,6 @@ pub struct Receipt {
     pub expiration_hours: u16, 
     pub email: String, 
     pub amount: u64,
-    pub transaction: Pubkey, 
 }
 
 // Sizing consts
@@ -91,7 +82,6 @@ const EXPIRATION_HOURS_LENGTH: usize = 2;
 const STRING_LENGTH_PREFIX: usize = 4; // Stores the size of the string.
 const MAX_EMAIL_LENGTH: usize = 254 * 4; // 254 chars max.
 const AMOUNT_LENGTH: usize = 8;
-const TRANSACTION_PUBLIC_KEY_LENGTH: usize = 32;
 
 impl Receipt {
     const LEN: usize = DISCRIMINATOR_LENGTH
@@ -100,8 +90,7 @@ impl Receipt {
     + TIMESTAMP_LENGTH
     + EXPIRATION_HOURS_LENGTH
     + STRING_LENGTH_PREFIX + MAX_EMAIL_LENGTH
-    + AMOUNT_LENGTH
-    + TRANSACTION_PUBLIC_KEY_LENGTH; 
+    + AMOUNT_LENGTH; 
 }
 
 #[error]

--- a/tests/flobrij.ts
+++ b/tests/flobrij.ts
@@ -34,22 +34,12 @@ describe('flobrij', () => {
     );
 
     const receipt = anchor.web3.Keypair.generate();
-    const fakeTransaction = anchor.web3.Keypair.generate();
 
     // const patronBalanceInitially = await anchor
     //   .getProvider()
     //   .connection.getBalance(anchor.getProvider().wallet.publicKey);
 
-    /*
-      transaction: Pubkey, 
-      recipient: Pubkey, 
-      email: String, 
-      amount: u64,
-      expiration_hours: u16
-    */
     const tx = await program.rpc.createReceipt(
-      fakeTransaction.publicKey,
-      newProvider.wallet.publicKey,
       EMAIL,
       TEST_AMOUNT,
       EXP_HOURS,
@@ -102,12 +92,12 @@ describe('flobrij', () => {
     assert.equal(receiptAccount.email, EMAIL);
     assert.ok(new anchor.BN(receiptAccount.amount).eq(TEST_AMOUNT));
     assert.equal(receiptAccount.expirationHours, EXP_HOURS);
+    assert.equal(receiptAccount.recipient, newProvider.wallet.publicKey.toString());
   });
 
   it('Create a receipt as a different user', async () => {
     const receipt = anchor.web3.Keypair.generate();
     const fakeRecipient = anchor.web3.Keypair.generate();
-    const fakeTransaction = anchor.web3.Keypair.generate();
     const fakeUser = anchor.web3.Keypair.generate();
     const signature = await program.provider.connection.requestAirdrop(
       fakeUser.publicKey,
@@ -122,8 +112,6 @@ describe('flobrij', () => {
       expiration_hours: u16
     */
     const tx = await program.rpc.createReceipt(
-      fakeTransaction.publicKey,
-      fakeRecipient.publicKey,
       EMAIL,
       TEST_AMOUNT,
       EXP_HOURS,


### PR DESCRIPTION
- [x] Implement transfer in Solana program, remove transaction, update tests. `amount` is now u64.
- [x] Wire up the front-end

Closes https://github.com/flobrij/issues/issues/15