### PR TITLE
Add and Manage Creator "Support Levels"

### DIFF
--- a/programs/flobrij/src/lib.rs
+++ b/programs/flobrij/src/lib.rs
@@ -50,7 +50,7 @@ pub mod flobrij {
     pub fn create_supportlevel(
         ctx: Context<CreateSupportLevel>,
         title: String,
-        monthly_price: u64,
+        price: u64,
         description: String,
         benefit: String,
     ) -> ProgramResult {
@@ -72,7 +72,7 @@ pub mod flobrij {
         }
 
         supportlevel.title = title;
-        supportlevel.monthly_price = monthly_price;
+        supportlevel.price = price;
         supportlevel.description = description;
         supportlevel.benefit = benefit;
 
@@ -82,7 +82,7 @@ pub mod flobrij {
     pub fn set_supportlevel(
         ctx: Context<SetSupportLevel>,
         title: String,
-        monthly_price: u64,
+        price: u64,
         description: String,
         benefit: String,
     ) -> ProgramResult {
@@ -101,10 +101,14 @@ pub mod flobrij {
         }
 
         supportlevel.title = title;
-        supportlevel.monthly_price = monthly_price;
+        supportlevel.price = price;
         supportlevel.description = description;
         supportlevel.benefit = benefit;
 
+        Ok(())
+    }
+
+    pub fn delete_supportlevel(_ctx: Context<DeleteSupportLevel>) -> ProgramResult {
         Ok(())
     }
 }
@@ -173,17 +177,24 @@ pub struct SetSupportLevel<'info> {
     pub supportlevel: Account<'info, SupportLevel>,
 }
 
+#[derive(Accounts)]
+pub struct DeleteSupportLevel<'info> {
+    #[account(mut, close = sol_dest)]
+    pub supportlevel: Account<'info, SupportLevel>,
+    sol_dest: AccountInfo<'info>,
+}
+
 #[account]
 pub struct SupportLevel {
     pub payer: Pubkey,
     pub title: String,
-    pub monthly_price: u64,
+    pub price: u64,
     pub description: String,
     pub benefit: String,
 }
 
 const MAX_SUPPORTLEVEL_PAYER_PUBLIC_KEY_LENGTH: usize = 32;
-const MAX_SUPPORTLEVEL_MONTHLY_PRICE_LENGTH: usize = 8;
+const MAX_SUPPORTLEVEL_PRICE_LENGTH: usize = 8;
 const MAX_SUPPORTLEVEL_TITLE_LENGTH: usize = 50 * 4; // 50 chars max.
 const MAX_SUPPORTLEVEL_DESCRIPTION_LENGTH: usize = 254 * 4; // 254 chars max.
 const MAX_SUPPORTLEVEL_BENEFIT_LENGTH: usize = 100 * 4; // 100 chars max.
@@ -193,7 +204,7 @@ impl SupportLevel {
         + MAX_SUPPORTLEVEL_PAYER_PUBLIC_KEY_LENGTH
         + STRING_LENGTH_PREFIX
         + MAX_SUPPORTLEVEL_TITLE_LENGTH
-        + MAX_SUPPORTLEVEL_MONTHLY_PRICE_LENGTH
+        + MAX_SUPPORTLEVEL_PRICE_LENGTH
         + STRING_LENGTH_PREFIX
         + MAX_SUPPORTLEVEL_DESCRIPTION_LENGTH
         + STRING_LENGTH_PREFIX

--- a/programs/flobrij/src/lib.rs
+++ b/programs/flobrij/src/lib.rs
@@ -78,6 +78,35 @@ pub mod flobrij {
 
         Ok(())
     }
+
+    pub fn set_supportlevel(
+        ctx: Context<SetSupportLevel>,
+        title: String,
+        monthly_price: u64,
+        description: String,
+        benefit: String,
+    ) -> ProgramResult {
+        let supportlevel: &mut Account<SupportLevel> = &mut ctx.accounts.supportlevel;
+
+        if title.chars().count() > 50 {
+            return Err(ErrorCode::TitleTooLong.into());
+        }
+
+        if description.chars().count() > 254 {
+            return Err(ErrorCode::DescriptionTooLong.into());
+        }
+
+        if benefit.chars().count() > 100 {
+            return Err(ErrorCode::BenefitTooLong.into());
+        }
+
+        supportlevel.title = title;
+        supportlevel.monthly_price = monthly_price;
+        supportlevel.description = description;
+        supportlevel.benefit = benefit;
+
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
@@ -136,6 +165,12 @@ pub struct CreateSupportLevel<'info> {
     pub payer: Signer<'info>,
     #[account(address = system_program::ID)]
     pub system_program: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct SetSupportLevel<'info> {
+    #[account(mut)]
+    pub supportlevel: Account<'info, SupportLevel>,
 }
 
 #[account]

--- a/programs/flobrij/src/lib.rs
+++ b/programs/flobrij/src/lib.rs
@@ -129,6 +129,7 @@ pub struct CreateReceipt<'info> {
 pub struct Receipt {
     pub payer: Pubkey,
     pub recipient: Pubkey,
+    // pub supportlevel: Pubkey,
     pub timestamp: i64,
     pub expiration_hours: u16,
     pub email: String,
@@ -175,6 +176,8 @@ pub struct CreateSupportLevel<'info> {
 pub struct SetSupportLevel<'info> {
     #[account(mut)]
     pub supportlevel: Account<'info, SupportLevel>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
 }
 
 #[derive(Accounts)]
@@ -191,6 +194,7 @@ pub struct SupportLevel {
     pub price: u64,
     pub description: String,
     pub benefit: String,
+    // pub expiration_hours: u16,
 }
 
 const MAX_SUPPORTLEVEL_PAYER_PUBLIC_KEY_LENGTH: usize = 32;

--- a/tests/receipt.test.ts
+++ b/tests/receipt.test.ts
@@ -3,7 +3,7 @@ import { Program } from '@project-serum/anchor';
 import { Flobrij } from '../target/types/flobrij';
 import * as assert from 'assert';
 
-describe('flobrij', () => {
+describe('Receipt', () => {
   anchor.setProvider(anchor.Provider.env());
 
   const program = anchor.workspace.Flobrij as Program<Flobrij>;

--- a/tests/receipt.test.ts
+++ b/tests/receipt.test.ts
@@ -3,16 +3,51 @@ import { Program } from '@project-serum/anchor';
 import { Flobrij } from '../target/types/flobrij';
 import * as assert from 'assert';
 
-describe('Receipt', () => {
+describe('PatronReceipt', () => {
   anchor.setProvider(anchor.Provider.env());
 
   const program = anchor.workspace.Flobrij as Program<Flobrij>;
 
   const EMAIL = 'test@test.com';
-  const TEST_AMOUNT = new anchor.BN(5000);
+  const TEST_AMOUNT = new anchor.BN(8000);
   const EXP_HOURS = 8760;
   const TEST_RECIPIENT = anchor.web3.Keypair.generate();
   const AIRDROP_AMOUNT = 1000000000;
+
+  const TEST_TITLE = 'Demigods';
+  const TEST_DESCRIPTION = 'Join the monthly Demigods newsletter';
+  const TEST_BENEFIT = 'Access to all our articles';
+
+  let supportlevel;
+
+  beforeEach(async function () {
+    supportlevel = anchor.web3.Keypair.generate();
+
+    await program.rpc.createSupportlevel(
+      TEST_TITLE,
+      TEST_AMOUNT,
+      TEST_DESCRIPTION,
+      TEST_BENEFIT,
+      {
+        accounts: {
+          supportlevel: supportlevel.publicKey,
+          payer: program.provider.wallet.publicKey,
+          systemProgram: anchor.web3.SystemProgram.programId,
+        },
+        signers: [supportlevel],
+      }
+    );
+  });
+
+  afterEach(async function () {
+    await program.rpc.deleteSupportlevel({
+      accounts: {
+        supportlevel: supportlevel.publicKey,
+        solDest: program.provider.wallet.publicKey,
+      },
+      signers: [],
+    });
+  });
 
   it('should pay creator and create a receipt for patron', async () => {
     // create new wallet for Creator
@@ -35,11 +70,12 @@ describe('Receipt', () => {
 
     const receipt = anchor.web3.Keypair.generate();
 
-    const tx = await program.rpc.createReceipt(EMAIL, TEST_AMOUNT, EXP_HOURS, {
+    const tx = await program.rpc.createReceipt(EMAIL, EXP_HOURS, {
       accounts: {
         receipt: receipt.publicKey,
         payer: program.provider.wallet.publicKey,
         recipient: newProvider.wallet.publicKey,
+        supportlevel: supportlevel.publicKey,
         systemProgram: anchor.web3.SystemProgram.programId,
       },
       signers: [receipt],
@@ -79,11 +115,12 @@ describe('Receipt', () => {
     );
     await program.provider.connection.confirmTransaction(signature);
 
-    const tx = await program.rpc.createReceipt(EMAIL, TEST_AMOUNT, EXP_HOURS, {
+    const tx = await program.rpc.createReceipt(EMAIL, EXP_HOURS, {
       accounts: {
         receipt: receipt.publicKey,
         payer: fakeUser.publicKey,
         recipient: fakeUser.publicKey,
+        supportlevel: supportlevel.publicKey,
         systemProgram: anchor.web3.SystemProgram.programId,
       },
       signers: [receipt, fakeUser],
@@ -133,11 +170,12 @@ describe('Receipt', () => {
     );
     await program.provider.connection.confirmTransaction(signature);
 
-    const tx = await program.rpc.createReceipt(EMAIL, TEST_AMOUNT, EXP_HOURS, {
+    const tx = await program.rpc.createReceipt(EMAIL, EXP_HOURS, {
       accounts: {
         receipt: receipt.publicKey,
         payer: fakeUser.publicKey,
         recipient: fakeUser.publicKey,
+        supportlevel: supportlevel.publicKey,
         systemProgram: anchor.web3.SystemProgram.programId,
       },
       signers: [receipt, fakeUser],

--- a/tests/supportlevel.test.ts
+++ b/tests/supportlevel.test.ts
@@ -7,12 +7,10 @@ const DISCRIMINATOR_LENGTH = 8;
 
 describe('SupportLevel', () => {
   anchor.setProvider(anchor.Provider.env());
-  let validatorRecords = 0;
-
   const program = anchor.workspace.Flobrij as Program<Flobrij>;
 
   const TEST_TITLE = 'Demigods';
-  const TEST_MONTHLY_PRICE = new anchor.BN(5000);
+  const TEST_PRICE = new anchor.BN(5000);
   const TEST_DESCRIPTION = 'Join the monthly Demigods newsletter';
   const TEST_BENEFIT = 'Access to all our articles';
 
@@ -20,12 +18,11 @@ describe('SupportLevel', () => {
     let supportlevel;
 
     beforeEach(async function () {
-      validatorRecords++;
       supportlevel = anchor.web3.Keypair.generate();
 
       await program.rpc.createSupportlevel(
         TEST_TITLE,
-        TEST_MONTHLY_PRICE,
+        TEST_PRICE,
         TEST_DESCRIPTION,
         TEST_BENEFIT,
         {
@@ -39,13 +36,23 @@ describe('SupportLevel', () => {
       );
     });
 
+    afterEach(async function () {
+      await program.rpc.deleteSupportlevel({
+        accounts: {
+          supportlevel: supportlevel.publicKey,
+          solDest: program.provider.wallet.publicKey,
+        },
+        signers: [],
+      });
+    });
+
     it('can create a new support level', async function () {
       const account = await program.account.supportLevel.fetch(
         supportlevel.publicKey
       );
 
       assert.equal(account.title, 'Demigods');
-      assert.ok(account.monthlyPrice.eq(new anchor.BN(5000)));
+      assert.ok(account.price.eq(new anchor.BN(5000)));
       assert.equal(account.description, 'Join the monthly Demigods newsletter');
       assert.equal(account.benefit, 'Access to all our articles');
       assert.equal(account.payer, program.provider.wallet.publicKey.toString());
@@ -54,7 +61,7 @@ describe('SupportLevel', () => {
     it('can edit my support level', async function () {
       await program.rpc.setSupportlevel(
         TEST_TITLE + ' edited',
-        TEST_MONTHLY_PRICE,
+        TEST_PRICE,
         TEST_DESCRIPTION,
         TEST_BENEFIT,
         {
@@ -72,16 +79,50 @@ describe('SupportLevel', () => {
       assert.equal(account.title, 'Demigods edited');
     });
 
-    it('can delete my support level');
+    it('can delete my support level', async function () {
+      const level = anchor.web3.Keypair.generate();
+
+      await program.rpc.createSupportlevel(
+        TEST_TITLE,
+        TEST_PRICE,
+        TEST_DESCRIPTION,
+        TEST_BENEFIT,
+        {
+          accounts: {
+            supportlevel: level.publicKey,
+            payer: program.provider.wallet.publicKey,
+            systemProgram: anchor.web3.SystemProgram.programId,
+          },
+          signers: [level],
+        }
+      );
+
+      await program.rpc.deleteSupportlevel({
+        accounts: {
+          supportlevel: level.publicKey,
+          solDest: program.provider.wallet.publicKey,
+        },
+        signers: [],
+      });
+
+      try {
+        const account = await program.account.supportLevel.fetch(
+          level.publicKey
+        );
+      } catch (e) {
+        return;
+      }
+
+      throw "test shouldn't reach here since account is deleted";
+    });
 
     it('can see list of all my support levels', async function () {
       // create a 2nd support level
-      validatorRecords++;
       const supportlevel2 = anchor.web3.Keypair.generate();
 
       await program.rpc.createSupportlevel(
         TEST_TITLE + '2',
-        TEST_MONTHLY_PRICE,
+        TEST_PRICE,
         TEST_DESCRIPTION,
         TEST_BENEFIT,
         {
@@ -114,8 +155,19 @@ describe('SupportLevel', () => {
       ]);
       // console.log('supportlevelAccounts', supportlevelAccounts);
 
-      assert.equal(supportlevelAccounts.length, validatorRecords);
+      assert.equal(supportlevelAccounts.length, 2);
+
+      await program.rpc.deleteSupportlevel({
+        accounts: {
+          supportlevel: supportlevel2.publicKey,
+          solDest: program.provider.wallet.publicKey,
+        },
+        signers: [],
+      });
     });
+    it(
+      'are only ones that can update (try to change with a different publicKey)'
+    );
     it('sees an error if email too long');
     it('sees an error if description too long');
     it('sees an error if benefit too long');

--- a/tests/supportlevel.test.ts
+++ b/tests/supportlevel.test.ts
@@ -1,0 +1,44 @@
+import * as anchor from '@project-serum/anchor';
+import { Program } from '@project-serum/anchor';
+import { Flobrij } from '../target/types/flobrij';
+import * as assert from 'assert';
+
+describe('SupportLevel', () => {
+  anchor.setProvider(anchor.Provider.env());
+
+  const program = anchor.workspace.Flobrij as Program<Flobrij>;
+
+  const TEST_TITLE = 'Demigods';
+  const TEST_MONTHLY_PRICE = new anchor.BN(5000);
+  const TEST_DESCRIPTION = 'Join the monthly Demigods newsletter';
+  const TEST_BENEFIT = 'Access to all our articles';
+
+  it('created successfully', async function () {
+    const supportlevel = anchor.web3.Keypair.generate();
+
+    const tx = await program.rpc.createSupportlevel(
+      TEST_TITLE,
+      TEST_MONTHLY_PRICE,
+      TEST_DESCRIPTION,
+      TEST_BENEFIT,
+      {
+        accounts: {
+          supportlevel: supportlevel.publicKey,
+          payer: program.provider.wallet.publicKey,
+          systemProgram: anchor.web3.SystemProgram.programId,
+        },
+        signers: [supportlevel],
+      }
+    );
+
+    const account = await program.account.supportLevel.fetch(
+      supportlevel.publicKey
+    );
+
+    assert.equal(account.title, 'Demigods');
+    assert.ok(account.monthlyPrice.eq(new anchor.BN(5000)));
+    assert.equal(account.description, 'Join the monthly Demigods newsletter');
+    assert.equal(account.benefit, 'Access to all our articles');
+    assert.equal(account.payer, program.provider.wallet.publicKey.toString());
+  });
+});

--- a/tests/supportlevel.test.ts
+++ b/tests/supportlevel.test.ts
@@ -241,10 +241,4 @@ describe('SupportLevel', () => {
       });
     });
   });
-
-  describe('as Patron', function () {
-    it('can see list of all available support levels');
-    it('can pick and pay for a support level');
-    it('can receive benefit of that subscription');
-  });
 });

--- a/tests/supportlevel.test.ts
+++ b/tests/supportlevel.test.ts
@@ -3,8 +3,11 @@ import { Program } from '@project-serum/anchor';
 import { Flobrij } from '../target/types/flobrij';
 import * as assert from 'assert';
 
+const DISCRIMINATOR_LENGTH = 8;
+
 describe('SupportLevel', () => {
   anchor.setProvider(anchor.Provider.env());
+  let validatorRecords = 0;
 
   const program = anchor.workspace.Flobrij as Program<Flobrij>;
 
@@ -13,32 +16,114 @@ describe('SupportLevel', () => {
   const TEST_DESCRIPTION = 'Join the monthly Demigods newsletter';
   const TEST_BENEFIT = 'Access to all our articles';
 
-  it('created successfully', async function () {
-    const supportlevel = anchor.web3.Keypair.generate();
+  describe('as Creator', function () {
+    let supportlevel;
 
-    const tx = await program.rpc.createSupportlevel(
-      TEST_TITLE,
-      TEST_MONTHLY_PRICE,
-      TEST_DESCRIPTION,
-      TEST_BENEFIT,
-      {
-        accounts: {
-          supportlevel: supportlevel.publicKey,
-          payer: program.provider.wallet.publicKey,
-          systemProgram: anchor.web3.SystemProgram.programId,
+    beforeEach(async function () {
+      validatorRecords++;
+      supportlevel = anchor.web3.Keypair.generate();
+
+      await program.rpc.createSupportlevel(
+        TEST_TITLE,
+        TEST_MONTHLY_PRICE,
+        TEST_DESCRIPTION,
+        TEST_BENEFIT,
+        {
+          accounts: {
+            supportlevel: supportlevel.publicKey,
+            payer: program.provider.wallet.publicKey,
+            systemProgram: anchor.web3.SystemProgram.programId,
+          },
+          signers: [supportlevel],
+        }
+      );
+    });
+
+    it('can create a new support level', async function () {
+      const account = await program.account.supportLevel.fetch(
+        supportlevel.publicKey
+      );
+
+      assert.equal(account.title, 'Demigods');
+      assert.ok(account.monthlyPrice.eq(new anchor.BN(5000)));
+      assert.equal(account.description, 'Join the monthly Demigods newsletter');
+      assert.equal(account.benefit, 'Access to all our articles');
+      assert.equal(account.payer, program.provider.wallet.publicKey.toString());
+    });
+
+    it('can edit my support level', async function () {
+      await program.rpc.setSupportlevel(
+        TEST_TITLE + ' edited',
+        TEST_MONTHLY_PRICE,
+        TEST_DESCRIPTION,
+        TEST_BENEFIT,
+        {
+          accounts: {
+            supportlevel: supportlevel.publicKey,
+          },
+          signers: [],
+        }
+      );
+
+      const account = await program.account.supportLevel.fetch(
+        supportlevel.publicKey
+      );
+
+      assert.equal(account.title, 'Demigods edited');
+    });
+
+    it('can delete my support level');
+
+    it('can see list of all my support levels', async function () {
+      // create a 2nd support level
+      validatorRecords++;
+      const supportlevel2 = anchor.web3.Keypair.generate();
+
+      await program.rpc.createSupportlevel(
+        TEST_TITLE + '2',
+        TEST_MONTHLY_PRICE,
+        TEST_DESCRIPTION,
+        TEST_BENEFIT,
+        {
+          accounts: {
+            supportlevel: supportlevel2.publicKey,
+            payer: program.provider.wallet.publicKey,
+            systemProgram: anchor.web3.SystemProgram.programId,
+          },
+          signers: [supportlevel2],
+        }
+      );
+
+      const account2 = await program.account.supportLevel.fetch(
+        supportlevel2.publicKey
+      );
+
+      assert.equal(account2.title, 'Demigods2');
+
+      // retrieve full list and filter by owner
+
+      const creator = program.provider.wallet.publicKey.toString();
+
+      const supportlevelAccounts = await program.account.supportLevel.all([
+        {
+          memcmp: {
+            offset: DISCRIMINATOR_LENGTH, // payer public key
+            bytes: creator,
+          },
         },
-        signers: [supportlevel],
-      }
-    );
+      ]);
+      // console.log('supportlevelAccounts', supportlevelAccounts);
 
-    const account = await program.account.supportLevel.fetch(
-      supportlevel.publicKey
-    );
+      assert.equal(supportlevelAccounts.length, validatorRecords);
+    });
+    it('sees an error if email too long');
+    it('sees an error if description too long');
+    it('sees an error if benefit too long');
+  });
 
-    assert.equal(account.title, 'Demigods');
-    assert.ok(account.monthlyPrice.eq(new anchor.BN(5000)));
-    assert.equal(account.description, 'Join the monthly Demigods newsletter');
-    assert.equal(account.benefit, 'Access to all our articles');
-    assert.equal(account.payer, program.provider.wallet.publicKey.toString());
+  describe('as Patron', function () {
+    it('can see list of all available support levels');
+    it('can pick and pay for a support level');
+    it('can receive benefit of that subscription');
   });
 });


### PR DESCRIPTION
## Tasks

- [x] Split Receipt and Support Level tests into separate files
- [x] Create Support Level entity
- [x] CRUD Operations for Creator's managing their Support Levels

## Acceptance Criteria

- [x] I can view my active Support Levels
- [x] I can delete an active Support Level
- [x] I can create and activate a new Support Level by specifying a title, a monthly price, a description and a benefit
- [x] Management of Creators support levels is decentralized, either on chain or through some other decentralized mechanism

Closes flobrij/issues/issues/6